### PR TITLE
Fix Invalid argument supplied for foreach()

### DIFF
--- a/src/getjump/Vk/Response/Response.php
+++ b/src/getjump/Vk/Response/Response.php
@@ -70,7 +70,7 @@ class Response
         if (!is_callable($callback)) {
             return;
         }
-        $data = false;
+        $data = [];
         $this->items ? $data = & $this->items : (!$this->data ? : $data = & $this->data);
         foreach ($data as $k => $v) {
             call_user_func_array($callback, [$k, $v]);


### PR DESCRIPTION
Hello, I fix error "Invalid argument supplied for foreach()"

The error occurs if the API returns an empty result, for example when dealing with the answers on pages (count \ offset)